### PR TITLE
Mise à jour 1.5.4

### DIFF
--- a/evaluations/ccpc/MANIFEST.xml
+++ b/evaluations/ccpc/MANIFEST.xml
@@ -3,6 +3,6 @@
 <informations>
 	<nom>CCPC</nom>
 	<auteur>Ali Bellamine</auteur>
-	<version>1.5.3</version>
+	<version>1.5.4</version>
 	<dateCreation>25/02/2015</dateCreation>
 </informations>

--- a/evaluations/ccpc/displayEvaluationResult/adminMail.php
+++ b/evaluations/ccpc/displayEvaluationResult/adminMail.php
@@ -103,12 +103,13 @@
 					
 				// On génère le PDF
 				$pdfPath = generatePDF(getEvaluationCCPCFullData($_POST['service'], $_POST['promotion'], $_POST['debutStage'], $_POST['finStage'], TRUE), FALSE, TRUE)['pdfPath'];
-				if (!file_exists(PLUGIN_PATH.'attachments/'.basename($pdfPath)) || !is_file(PLUGIN_PATH.'attachments/'.basename($pdfPath)))
+				
+				if (!file_exists(PLUGIN_PATH.'attachments/'.$_POST['codeCampagne'].' - '.basename($pdfPath)) || !is_file(PLUGIN_PATH.'attachments/'.$_POST['codeCampagne'].' - '.basename($pdfPath)))
 				{
-					copy($pdfPath, PLUGIN_PATH.'attachments/'.basename($pdfPath));
+					copy($pdfPath, PLUGIN_PATH.'attachments/'.$_POST['codeCampagne'].' - '.basename($pdfPath));
 				}
 								
-			$attachments = array('Evaluations.pdf' => array('path' => PLUGIN_PATH.'attachments/'.basename($pdfPath), 'url' => ROOT.'evaluations/ccpc/attachments/'.basename($pdfPath)));
+			$attachments = array('Evaluations.pdf' => array('path' => PLUGIN_PATH.'attachments/'.$_POST['codeCampagne'].' - '.basename($pdfPath), 'url' => ROOT.'evaluations/ccpc/attachments/'.$_POST['codeCampagne'].' - '.basename($pdfPath)));
 				
 			// Destinataire
 			$chefId = getServiceInfo($_POST['service'])['chef']['id'];

--- a/evaluations/ccpc/displayEvaluationResult/contentEvaluationData.php
+++ b/evaluations/ccpc/displayEvaluationResult/contentEvaluationData.php
@@ -57,6 +57,7 @@
 		$sql = 'SELECT e.promotion promotionId, p.nom promotionNom, e.debutStage dateDebut, e.finStage dateFin
 					FROM eval_ccpc_resultats e
 					INNER JOIN promotion p ON p.id = e.promotion
+					INNER JOIN service s ON e.service = s.id
 					WHERE e.service = ?';
 					
 			// Liste des périodes de stages correspondant au filtre
@@ -82,6 +83,16 @@
 			$fastSelectSqlCore .= ' AND e.date <= "'.$allowedDate.'" ';
 		}
 		
+		/*
+			Ne pas afficher les évaluations des autres services aux chef de service
+		*/
+		
+		if ($_SESSION['rang'] == 2 && defined('CONFIG_EVAL_CCPC_RESTRICTEVALUATIONACCESSSERVICE') && CONFIG_EVAL_CCPC_RESTRICTEVALUATIONACCESSSERVICE == TRUE)
+		{			
+			$sql .= ' AND s.chef = "'.$_SESSION['id'].'"';
+			$fastSelectSqlCore .= ' AND s.chef = "'.$_SESSION['id'].'"';
+		}
+
 		$res = $db -> prepare($sql);
 		$res -> execute(array($_GET['service']));
 		

--- a/evaluations/ccpc/displayEvaluationResult/listEvaluationData.php
+++ b/evaluations/ccpc/displayEvaluationResult/listEvaluationData.php
@@ -204,6 +204,19 @@
 		}
 		
 		/*
+			Ne pas afficher les évaluations des autres services aux chef de service
+		*/
+		
+		if ($_SESSION['rang'] == 2 && defined('CONFIG_EVAL_CCPC_RESTRICTEVALUATIONACCESSSERVICE') && CONFIG_EVAL_CCPC_RESTRICTEVALUATIONACCESSSERVICE == TRUE)
+		{
+			if ($whereSqlFilter == '') { $whereSqlFilter .= 'WHERE '; } else { $whereSqlFilter .= ' AND '; }
+			if ($whereSqlContent == '') { $whereSqlContent .= 'WHERE '; } else { $whereSqlContent .= ' AND '; }
+			
+			$whereSqlFilter .= ' s.chef = "'.$_SESSION['id'].'"';
+			$whereSqlContent .= ' s.chef = "'.$_SESSION['id'].'"';
+		}
+
+		/*
 			Pages (LIMIT)
 		*/
 		

--- a/evaluations/ccpc/settings.php
+++ b/evaluations/ccpc/settings.php
@@ -25,5 +25,6 @@
 	define('CONFIG_EVAL_CCPC_DELAIDISPOEVAL_STUDENT', 15); // Délai en jours avant de permettre l'accès aux évaluations pour les étudiants
 	define('CONFIG_EVAL_CCPC_DELAIDISPOEVAL_TEACHER', 30); // Délai en jours avant de permettre l'accès aux évaluations pour les enseignants
 	define('CONFIG_EVAL_CCPC_NBEVALPARPAGE', 10); // Nombre d'évaluations à afficher par page, 10 par défaut
+	define('CONFIG_EVAL_CCPC_RESTRICTEVALUATIONACCESSSERVICE', TRUE); // Si TRUE : empêche aux chefs de service d'accéder à d'autres évaluations que celles de son service
 	
 ?>


### PR DESCRIPTION
- Correction de bug : nom des pièces jointes maintenant unique
- Ajout d'une option dans settings, permettant d'interdire aux
  utilisateurs de rang 2 d'accéder à des données d'évaluation d'autres
  services que le leurs
